### PR TITLE
Allows it to run on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Setup
     yum install -y ansible rubygem-thor
     gem install parseconfig
   ```
-
+   - OSX:
+  ```
+    # Installs ansible and python 2 
+    brew install ansible python
+    # Required ruby gems
+    gem install thor parseconfig
+  ```
 - Setup for a specific cloud:
   - [AWS](README_AWS.md)
   - [GCE](README_GCE.md)

--- a/README_AWS.md
+++ b/README_AWS.md
@@ -38,8 +38,13 @@ Alternatively, you can configure your ssh-agent to hold the credentials to conne
 Install Dependencies
 --------------------
 1. Ansible requires python-boto for aws operations:
+RHEL/CentOS/Fedora
 ```
   yum install -y ansible python-boto
+```
+OSX:
+```
+  pip install -U boto
 ```
 
 

--- a/lib/aws_command.rb
+++ b/lib/aws_command.rb
@@ -143,7 +143,7 @@ module OpenShift
 
       desc "ssh", "Ssh to an instance"
       def ssh(*ssh_ops, host)
-        if host =~ /^([\w\d_.-]+)@([\w\d-_.]+)/
+        if host =~ /^([\w\d_.\-]+)@([\w\d\-_.]+)/
           user = $1
           host = $2
         end

--- a/lib/gce_command.rb
+++ b/lib/gce_command.rb
@@ -140,7 +140,7 @@ module OpenShift
              :desc => 'A relative path where files are written to.'
       desc "scp_from", "scp files from an instance"
       def scp_from(*ssh_ops, host)
-        if host =~ /^([\w\d_.-]+)@([\w\d-_.]+)$/
+        if host =~ /^([\w\d_.\-]+)@([\w\d\-_.]+)$/
           user = $1
           host = $2
         end
@@ -172,7 +172,7 @@ module OpenShift
 
       desc "ssh", "Ssh to an instance"
       def ssh(*ssh_ops, host)
-        if host =~ /^([\w\d_.-]+)@([\w\d-_.]+)/
+        if host =~ /^([\w\d_.\-]+)@([\w\d\-_.]+)/
           user = $1
           host = $2
         end


### PR DESCRIPTION
Versions of ruby ported on OSX requires escaping of hyphens in regexp
Adds documentation on packages required by OSX to run openshift-online-ansible on OSX
