### PR TITLE
Bail if the heat-stack for the network is present, but not OK

### DIFF
--- a/playbooks/os/openshift-cluster/tasks/configure_openstack_network.yml
+++ b/playbooks/os/openshift-cluster/tasks/configure_openstack_network.yml
@@ -3,7 +3,8 @@
   command: 'heat stack-show {{ openstack_network_prefix }}-network-stack'
   register: stack_show_result
   changed_when: false
-  failed_when: stack_show_result.rc != 0 and 'Stack not found' not in stack_show_result.stderr
+  failed_when: (stack_show_result.rc != 0 and 'Stack not found' not in stack_show_result.stderr) or
+               (stack_show_result.rc == 0 and '_COMPLETE' not in stack_show_result.stdout)
 
 - name: Create network
   command: 'heat stack-create -f files/heat_stack.yml -P cluster-id={{ cluster_id }} -P network-prefix={{ openstack_network_prefix }} -P dns-nameservers={{ openstack_network_dns | join(",") }} -P cidr={{ openstack_network_cidr }} -P ssh-incoming=0.0.0.0/0 {{ openstack_network_prefix }}-network-stack'


### PR DESCRIPTION
Bail if the heat-stack for the network is present, but not in UPDATE_COMPLETED state. (e.g. it is in UPDATED_FAILED state).
